### PR TITLE
Remove Subscribe Link and Initial Popup

### DIFF
--- a/components/Layout/Footer.tsx
+++ b/components/Layout/Footer.tsx
@@ -32,12 +32,7 @@ export const Footer: FC = () => {
       {/* <Link href="/privacy">
         <a className="text-neutral-500 hover:text-primary-500">Privacy Policy</a>
       </Link> */}
-      <a
-        onClick={handleOpenSubscriptionPopup}
-        className="text-neutral-500 hover:text-primary-500 cursor-pointer"
-      >
-        Subscribe
-      </a>
+      {/* Subscribe link removed */}
       <Link href="https://www.producthunt.com/posts/sanatanadharma-xyz?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-sanatanadharma-xyz" target="_blank" rel="noopener noreferrer">
         <img src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=416280&theme=neutral" alt="SanatanaDharma.xyz - Sanatana Dharma Chatbot: Revealing Our Heritage 🕉️ | Product Hunt" style={{ width: '250px', height: '34px' }} width="250" height="54" />
       </Link>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -50,10 +50,10 @@ export default function Home() {
     }
   }
 
-  // Load the subscription popup state from local storage
-  useEffect(() => {
-    showPopup();
-  }, []);
+  // Subscription popup on load disabled
+  // useEffect(() => {
+  //   showPopup();
+  // }, []);
 
   // Function to handle closing the subscription popup
   const handleCloseSubscriptionPopup = () => {


### PR DESCRIPTION
### Summary of changes
- Removed the "Subscribe" link from the footer component
- Disabled the automatic subscription popup that appears when the page loads
- Subscription functionality remains available through other interaction points

### Motivation/Context
These changes aim to make the user experience less intrusive by:
- Removing redundant subscription entry points
- Preventing automatic popup interruptions during initial page load
- Allowing users to focus on the main content immediately upon visiting

### Implementation details
Changes made in two files:

**`components/Layout/Footer.tsx`**:
- Removed the Subscribe link and its associated click handler
- Kept the Product Hunt badge as the main footer element

**`pages/index.tsx`**:
- Commented out the initial useEffect hook that triggered the subscription popup
- Maintained the popup functionality for other interaction points
- Subscription state management logic remains intact for future use

### Potential impacts and considerations
- Users will no longer see the subscription popup immediately upon page load
- The subscription feature is still accessible through other interaction points
- No impact on existing subscribed users or subscription handling logic
- Improved initial page load experience for new visitors

These changes align with best practices for non-intrusive user experience while maintaining the subscription functionality for engaged users.